### PR TITLE
add travis CI to release on pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 *.py[co]
+# Ignore packaging artifacts
+build/
+dist/
+sdist/
+*.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: python
+python:
+  - '3.6'
+
+# By default travis tries to install the package with `pip install -r
+# requirements.txt` but we don't need a requirements.txt so we override the
+# default command
+install:
+  - python setup.py install
+
+# By default travis runs pytest, but we don't have tests so we just make sure
+# the package is importable instead
+script:
+  - python -m netns
+
+# Upload a new release to pypi when a new tag is pushed
+# See also: https://docs.travis-ci.com/user/deployment/pypi/
+deploy:
+  provider: pypi
+  # Optionally a custom server can be provided. For instance to upload to test.pypi.org:
+  # server: https://upload.pypi.org/legacy/
+  user: little-dude
+  # To generate the secure password:
+  #
+  #     travis encrypt 'passwordwithonlyalphanumericcharacters'  --add deploy.password
+  #
+  # See also:
+  # https://docs.travis-ci.com/user/encryption-keys/
+  password:
+    secure: W98UI7hPWt+zQ5cUjWab2Z89WGBpHO8MvOa8TYM0zg9HVXBBWrZDtr4hKyASGl17n6nSa+SjiavfNAQX/w9ZTM7bh7XAlqr9bl00A56ObRaXcqraWB3MqB+D4GWhI3k+teV9OhrrxlNW5FjJnURpsvOmIYPhA3AqAKV59I/K6prFTFf6EKWk71lzIUsieyooEJAGX2rf23Gcuj8OfMwc8kpOIB3XpUCGEUzEhEyYDNWDTWNAfTxC+diE2GUEZ2yDIJBnHB2ULCHb/xVTOtE9PjJ+wNEjU/mNu4gvP0h3NryPTJQpoBHgdh/A8NN4AETdafunR/24eSClCnjn5dCMjhauuZZa4PPDxW8ZHw8kVSP57C6RehEslzLHf875rTq2ZNxewxsD2OeiMzYgoRKcmCCLJNpOeSFdHaaSzc63wgNjvQ49l3BEvuwBgN0+2tEQiPc9XjqIPLRBURqsdN2jshOBXiUJcgfOBTJWoz8CQBA0fmE7U37YYyJlPt2wmKFRN8Gig2xoiGt8criXzsaa9nwvDmOliJtatbGaqC126jlVQ1tCp1YOcYKxqzOI/vQMXbAeSRJ8ZdHXOKj/Wbo2rPNl/PdMgj0hs515hHBY4QiFX/RDvdUl5wBRqOwcPHrPjB9kYivFLKcvPwqjHKnGg8RJw5WbhwZ834p7OWVMPas=
+  on:
+    tags: true

--- a/setup.py
+++ b/setup.py
@@ -10,4 +10,4 @@ setuptools.setup(
     name='netns',
     license='GPLv3',
     py_modules=['netns'],
-    version=1, )
+    version='1.0')

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,6 @@ setuptools.setup(
     url='http://github.com/larsks/python-netns',
     description='Wrapper for the Linux setns() system call',
     name='netns',
+    license='GPLv3',
     py_modules=['netns'],
     version=1, )


### PR DESCRIPTION
As said in https://github.com/larsks/python-netns/issues/2 I uploaded `python-netns` on pypi. I know you don't want to maintain the package yourself, but in case you change your mind here is the travic.yml I used to upload the package. You'd just have to update the credentials if you want to use it.

I also added some things to the gitignore to keep a clean workspace when building the package locally. I can get rid of that if you want.

Finally I added the license to the setup.py so that it shows up on pypi.